### PR TITLE
Fix queues to only pull from current trap deployment

### DIFF
--- a/trapdata/cli/base.py
+++ b/trapdata/cli/base.py
@@ -1,10 +1,11 @@
 import typer
 
-from trapdata.cli import export
+from trapdata.cli import export, shell
 
 
 cli = typer.Typer()
 cli.add_typer(export.cli, name="export")
+cli.add_typer(shell.cli, name="shell")
 
 
 if __name__ == "__main__":

--- a/trapdata/cli/scan.py
+++ b/trapdata/cli/scan.py
@@ -64,6 +64,8 @@ def detections(
 ) -> Optional[str]:
     """
     Export detected objects from database in the specified format.
+
+    Dates and
     """
     objects = get_detected_objects(settings.database_url, limit=limit, offset=offset)
     logger.info(f"Preparing to export {objects.count()} records as {format}")

--- a/trapdata/cli/shell.py
+++ b/trapdata/cli/shell.py
@@ -1,0 +1,26 @@
+import typer
+
+import sqlalchemy as sa
+from sqlalchemy import select
+
+from trapdata.db.base import get_session_class
+from trapdata.settings import settings
+from trapdata.db.models import *
+
+cli = typer.Typer()
+
+
+@cli.command()
+def ipython():
+    """
+    Open python shell with project loaded.
+    """
+    Session = get_session_class(settings.database_url)
+    session = Session()
+    import ipdb
+
+    ipdb.set_trace()
+
+
+if __name__ == "__main__":
+    cli()

--- a/trapdata/common/types.py
+++ b/trapdata/common/types.py
@@ -1,3 +1,5 @@
+import pathlib
+from typing import Union
 from dataclasses import dataclass
 
 
@@ -11,3 +13,6 @@ class CoordinateDMS:
 class Location:
     latitude: CoordinateDMS
     longitude: CoordinateDMS
+
+
+FilePath = Union[pathlib.Path, str]

--- a/trapdata/db/models/images.py
+++ b/trapdata/db/models/images.py
@@ -86,7 +86,7 @@ def completely_classified(db_path, image_id):
 
     with get_session(db_path) as sesh:
         img = sesh.query(TrapImage).get(image_id)
-        if img.in_queue or not img.last_processed:
+        if not img or not img.last_processed or img.in_queue:
             return False
 
         else:

--- a/trapdata/db/models/queue.py
+++ b/trapdata/db/models/queue.py
@@ -1,19 +1,37 @@
+from typing import Union, Sequence
+
 import sqlalchemy as sa
 
 from trapdata.db import get_session
 from trapdata import logger
 from trapdata import constants
+from trapdata.common.types import FilePath
 from trapdata.db.models.images import TrapImage
-from trapdata.db.models.detections import (
-    DetectedObject,
-)
+from trapdata.db.models.detections import DetectedObject
+from trapdata.db.models.events import MonitoringSession
 
 
 class QueueManager:
     name = "Unnamed Queue"
+    base_directory: FilePath
 
-    def __init__(self, db_path):
+    def __init__(self, db_path: str, base_directory: FilePath):
         self.db_path = db_path
+        self.base_directory = base_directory
+
+    def ids(self) -> sa.ScalarSelect:
+        """
+        Return subquery of all IDs managed by the scope of this queue.
+        """
+        return sa.select().scalar_subquery()
+
+    def get_model(self):
+        """
+        The primary SQLAlchemy model for common queries.
+
+        If this is a custom queue, you must override the default methods
+        """
+        raise NotImplementedError
 
     def queue_count(self):
         raise NotImplementedError
@@ -24,16 +42,16 @@ class QueueManager:
     def done_count(self):
         raise NotImplementedError
 
-    def add_unprocessed(self):
+    def add_unprocessed(self, *_):
         raise NotImplementedError
 
-    def clear_queue(self):
+    def clear_queue(self, *_):
         raise NotImplementedError
 
     def status(self):
         return NotImplementedError
 
-    def pull_n_from_queue(self, n):
+    def pull_n_from_queue(self, n: int):
         return NotImplementedError
 
     def process_queue(self, model):
@@ -46,72 +64,73 @@ class ImageQueue(QueueManager):
     name = "Images"
     description = "Raw images from camera needing object detection"
 
-    def queue_count(self):
-        with get_session(self.db_path) as sesh:
-            count = sesh.scalar(
-                sa.select(sa.func.count(TrapImage.id)).where(TrapImage.in_queue == True)
+    def ids(self) -> sa.ScalarSelect:
+        """
+        Return subquery of all IDs managed by the scope of this queue.
+        """
+        return (
+            sa.select(TrapImage.id)
+            .where(MonitoringSession.base_directory == str(self.base_directory))
+            .join(
+                MonitoringSession,
+                TrapImage.monitoring_session_id == MonitoringSession.id,
             )
-            logger.debug(f"Images in queue: {count}")
+            .scalar_subquery()
+        )
+
+    def queue_count(self) -> Union[int, None]:
+        with get_session(self.db_path) as sesh:
+            stmt = sa.select(sa.func.count(TrapImage.id)).where(
+                (TrapImage.id.in_(self.ids()) & (TrapImage.in_queue.is_(True)))
+            )
+            count = sesh.execute(stmt).scalar()
             return count
 
-    def unprocessed_count(self):
+    def unprocessed_count(self) -> Union[int, None]:
         with get_session(self.db_path) as sesh:
-            return sesh.query(TrapImage).filter_by(last_processed=None).count()
-
-    def done_count(self):
-        with get_session(self.db_path) as sesh:
-            return (
-                sesh.query(TrapImage)
-                .filter(TrapImage.last_processed.is_not(None))
-                .count()
+            stmt = sa.select(sa.func.count(TrapImage.id)).where(
+                (TrapImage.id.in_(self.ids()) & (TrapImage.last_processed.is_(None)))
             )
+            count = sesh.execute(stmt).scalar()
+            return count
 
-    def add_unprocessed(self, *args):
-        orm_objects = []
+    def done_count(self) -> Union[int, None]:
         with get_session(self.db_path) as sesh:
-            images = (
-                sesh.query(TrapImage)
-                .filter_by(
-                    in_queue=False,
-                    last_processed=None,
+            stmt = sa.select(sa.func.count(TrapImage.id)).where(
+                (TrapImage.id.in_(self.ids()) & (TrapImage.last_processed.is_not(None)))
+            )
+            count = sesh.execute(stmt).scalar()
+            return count
+
+    def add_unprocessed(self, *_) -> None:
+        logger.info("Adding all unprocessed deployment images to queue")
+        with get_session(self.db_path) as sesh:
+            stmt = (
+                sa.update(TrapImage)
+                .where(
+                    TrapImage.id.in_(self.ids()) & TrapImage.last_processed.is_(None)
                 )
-                .all()
+                .values({"in_queue": True})
             )
-        for image in images:
-            image.in_queue = True
-            orm_objects.append(image)
-
-        with get_session(self.db_path) as sesh:
-            logger.info(f"Bulk saving {len(images)} images to queue")
-            sesh.bulk_save_objects(images)
+            sesh.execute(stmt)
             sesh.commit()
 
+    def clear_queue(self, *_) -> None:
+        logger.info("Clearing all deployment images in queue")
         with get_session(self.db_path) as sesh:
-            count = sesh.query(TrapImage).filter_by(last_processed=None).count()
-
-        return count
-
-    def clear_queue(self, *args):
-        logger.info("Clearing images in queue")
-
-        orm_objects = []
-        with get_session(self.db_path) as sesh:
-            images = sesh.query(TrapImage).filter_by(in_queue=True).all()
-
-        for image in images:
-            image.in_queue = False
-            orm_objects.append(image)
-
-        with get_session(self.db_path) as sesh:
-            logger.info(f"Removing {len(orm_objects)} images from queue")
-            sesh.bulk_save_objects(orm_objects)
+            stmt = (
+                sa.update(TrapImage)
+                .where(TrapImage.id.in_(self.ids()) & TrapImage.in_queue.is_(True))
+                .values({"in_queue": False})
+            )
+            sesh.execute(stmt)
             sesh.commit()
 
-    def pull_n_from_queue(self, n):
+    def pull_n_from_queue(self, n: int) -> Sequence[TrapImage]:
         logger.debug(f"Attempting to pull {n} images from queue")
         select_stmt = (
             sa.select(TrapImage.id)
-            .where((TrapImage.in_queue == True))
+            .where(TrapImage.id.in_(self.ids()) & (TrapImage.in_queue.is_(True)))
             .limit(n)
             .with_for_update()
         )
@@ -123,9 +142,8 @@ class ImageQueue(QueueManager):
             .returning(TrapImage)
         )
         with get_session(self.db_path) as sesh:
-            records = sesh.execute(update_stmt).unique().all()
+            images = sesh.execute(update_stmt).unique().scalars().all()
             sesh.commit()
-            images = [record[0] for record in records]
             logger.info(f"Pulled {len(images)} images from queue")
             return images
 
@@ -134,72 +152,95 @@ class DetectedObjectQueue(QueueManager):
     name = "Detected objects"
     description = "Objects that were detected in an image but have not been classified"
 
+    def ids(self) -> sa.ScalarSelect:
+        """
+        Return subquery of all IDs managed by the scope of this queue.
+        """
+        return (
+            sa.select(DetectedObject.id)
+            .where(
+                (MonitoringSession.base_directory == str(self.base_directory))
+                & DetectedObject.bbox.is_not(None)
+            )
+            .join(
+                MonitoringSession,
+                DetectedObject.monitoring_session_id == MonitoringSession.id,
+            )
+            .scalar_subquery()
+        )
+
     def queue_count(self):
         with get_session(self.db_path) as sesh:
-            return (
-                sesh.query(DetectedObject)
-                .filter(DetectedObject.bbox.is_not(None))
-                .filter_by(
-                    in_queue=True,
-                    binary_label=None,
+            stmt = sa.select(sa.func.count(DetectedObject.id)).where(
+                (
+                    (DetectedObject.id.in_(self.ids()))
+                    & DetectedObject.in_queue.is_(True)
+                    & (DetectedObject.binary_label.is_(None))
                 )
-                .count()
             )
+            count = sesh.execute(stmt).scalar()
+            return count
 
     def unprocessed_count(self):
         with get_session(self.db_path) as sesh:
-            return sesh.query(DetectedObject).filter_by(binary_label=None).count()
+            stmt = sa.select(sa.func.count(DetectedObject.id)).where(
+                (
+                    (DetectedObject.id.in_(self.ids()))
+                    & (DetectedObject.binary_label.is_(None))
+                )
+            )
+            count = sesh.execute(stmt).scalar()
+            return count
 
     def done_count(self):
         with get_session(self.db_path) as sesh:
-            return (
-                sesh.query(DetectedObject)
-                .filter(DetectedObject.binary_label.is_not(None))
-                .count()
+            stmt = sa.select(sa.func.count(DetectedObject.id)).where(
+                (
+                    (DetectedObject.id.in_(self.ids()))
+                    & (DetectedObject.binary_label.is_not(None))
+                )
             )
+            count = sesh.execute(stmt).scalar()
+            return count
 
-    def add_unprocessed(self, *args):
+    def add_unprocessed(self, *_) -> None:
+        logger.info(f"Adding detected objects from deployment to queue")
         with get_session(self.db_path) as sesh:
-            objects = []
-            for obj in (
-                sesh.query(DetectedObject)
-                .filter_by(in_queue=False, binary_label=None)
-                .all()
-            ):
-                obj.in_queue = True
-                objects.append(obj)
-            logger.info(f"Adding {len(objects)} objects to queue")
-            sesh.bulk_save_objects(objects)
+            stmt = (
+                sa.update(DetectedObject)
+                .where(
+                    (DetectedObject.id.in_(self.ids()))
+                    & (DetectedObject.in_queue.is_(False))
+                    & (DetectedObject.binary_label.is_(None))
+                )
+                .values({"in_queue": True})
+            )
+            sesh.execute(stmt)
             sesh.commit()
 
-    def clear_queue(self, *args):
-        logger.info("Clearing detected objects in queue")
-
-        orm_objects = []
+    def clear_queue(self, *_) -> None:
+        logger.info("Removing detected objects from deployment from queue")
         with get_session(self.db_path) as sesh:
-            objects = (
-                sesh.query(DetectedObject)
-                .filter_by(in_queue=True, binary_label=None)
-                .all()
+            stmt = (
+                sa.update(DetectedObject)
+                .where(
+                    (DetectedObject.id.in_(self.ids()))
+                    & (DetectedObject.in_queue.is_(True))
+                    & (DetectedObject.binary_label.is_(None))
+                )
+                .values({"in_queue": False})
             )
-
-        for obj in objects:
-            obj.in_queue = False
-            orm_objects.append(obj)
-
-        with get_session(self.db_path) as sesh:
-            logger.info(f"Removing {len(orm_objects)} objects from queue")
-            sesh.bulk_save_objects(orm_objects)
+            sesh.execute(stmt)
             sesh.commit()
 
-    def pull_n_from_queue(self, n):
+    def pull_n_from_queue(self, n: int) -> Sequence[DetectedObject]:
         logger.debug(f"Attempting to pull {n} detected objects from queue")
         select_stmt = (
             sa.select(DetectedObject.id)
             .where(
-                (DetectedObject.in_queue == True)
-                & (DetectedObject.binary_label == None)
-                & (DetectedObject.bbox.is_not(None))
+                (DetectedObject.id.in_(self.ids()))
+                & (DetectedObject.in_queue.is_(True))
+                & (DetectedObject.binary_label.is_(None))
             )
             .limit(n)
             .with_for_update()
@@ -213,106 +254,114 @@ class DetectedObjectQueue(QueueManager):
         with get_session(self.db_path) as sesh:
             record_ids = sesh.execute(update_stmt).unique().scalars().all()
             sesh.commit()
-            records = (
+            objs = (
                 sesh.execute(
                     sa.select(DetectedObject).where(DetectedObject.id.in_(record_ids))
                 )
                 .unique()
+                .scalars()
                 .all()
             )
-            objs = [record[0] for record in records]
             logger.info(f"Pulled {len(objs)} detected objects from queue")
             return objs
 
 
 class UnclassifiedObjectQueue(QueueManager):
-    name = "Unclassified species"
+    name = "Unclassified objects"
     description = """
     Objects that have been identified as something of interest (e.g. a moth)
     but have not yet been classified to the species level.
     """
 
-    def queue_count(self):
+    def ids(self) -> sa.ScalarSelect:
+        """
+        Return subquery of all IDs managed by the scope of this queue.
+        """
+        return (
+            sa.select(DetectedObject.id)
+            .where(
+                (MonitoringSession.base_directory == str(self.base_directory))
+                & (DetectedObject.binary_label == constants.POSITIVE_BINARY_LABEL)
+            )
+            .join(
+                MonitoringSession,
+                DetectedObject.monitoring_session_id == MonitoringSession.id,
+            )
+            .scalar_subquery()
+        )
+
+    def queue_count(self) -> Union[int, None]:
         with get_session(self.db_path) as sesh:
-            return (
-                sesh.query(DetectedObject)
-                .filter_by(
-                    in_queue=True,
-                    specific_label=None,
-                    binary_label=constants.POSITIVE_BINARY_LABEL,
+            stmt = sa.select(sa.func.count(DetectedObject.id)).where(
+                (
+                    (DetectedObject.id.in_(self.ids()))
+                    & DetectedObject.in_queue.is_(True)
+                    & DetectedObject.specific_label.is_(None)
                 )
-                .count()
             )
+            count = sesh.execute(stmt).scalar()
+            return count
 
-    def unprocessed_count(self):
+    def unprocessed_count(self) -> Union[int, None]:
         with get_session(self.db_path) as sesh:
-            return (
-                sesh.query(DetectedObject)
-                .filter_by(
-                    specific_label=None,
-                    binary_label=constants.POSITIVE_BINARY_LABEL,
+            stmt = sa.select(sa.func.count(DetectedObject.id)).where(
+                (
+                    (DetectedObject.id.in_(self.ids()))
+                    & DetectedObject.specific_label.is_(None)
                 )
-                .count()
             )
+            count = sesh.execute(stmt).scalar()
+            return count
 
-    def done_count(self):
+    def done_count(self) -> Union[int, None]:
         with get_session(self.db_path) as sesh:
-            return (
-                sesh.query(DetectedObject)
-                .filter(DetectedObject.specific_label.is_not(None))
-                .count()
-            )
-
-    def add_unprocessed(self, *args):
-        orm_objects = []
-        with get_session(self.db_path) as sesh:
-            objects = (
-                sesh.query(DetectedObject)
-                .filter_by(
-                    in_queue=False,
-                    specific_label=None,
-                    binary_label=constants.POSITIVE_BINARY_LABEL,
+            stmt = sa.select(sa.func.count(DetectedObject.id)).where(
+                (
+                    (DetectedObject.id.in_(self.ids()))
+                    & DetectedObject.specific_label.is_not(None)
                 )
-                .all()
             )
+            count = sesh.execute(stmt).scalar()
+            return count
 
-        for obj in objects:
-            obj.in_queue = True
-            orm_objects.append(obj)
-
+    def add_unprocessed(self, *_) -> None:
+        logger.info("Adding unclassified objects from deployment to queue")
         with get_session(self.db_path) as sesh:
-            logger.info(f"Adding {len(orm_objects)} objects to queue")
-            sesh.bulk_save_objects(orm_objects)
+            stmt = (
+                sa.update(DetectedObject)
+                .where(
+                    (DetectedObject.id.in_(self.ids()))
+                    & (DetectedObject.in_queue.is_(False))
+                    & (DetectedObject.specific_label.is_(None))
+                )
+                .values({"in_queue": True})
+            )
+            sesh.execute(stmt)
             sesh.commit()
 
-    def clear_queue(self, *args):
-        logger.info("Clearing unclassified objects in queue")
-
+    def clear_queue(self, *_) -> None:
+        logger.info("Removing unclassified objects from deployment from queue")
         with get_session(self.db_path) as sesh:
-            objects = []
-            for obj in (
-                sesh.query(DetectedObject)
-                .filter_by(
-                    in_queue=True,
-                    specific_label=None,
-                    binary_label=constants.POSITIVE_BINARY_LABEL,
+            stmt = (
+                sa.update(DetectedObject)
+                .where(
+                    (DetectedObject.id.in_(self.ids()))
+                    & (DetectedObject.in_queue.is_(True))
+                    & (DetectedObject.specific_label.is_(None))
                 )
-                .all()
-            ):
-                obj.in_queue = False
-                objects.append(obj)
-            logger.info(f"Clearing {len(objects)} objects in queue")
-            sesh.bulk_save_objects(objects)
+                .values({"in_queue": False})
+            )
+            sesh.execute(stmt)
             sesh.commit()
 
-    def pull_n_from_queue(self, n):
+    def pull_n_from_queue(self, n: int) -> Sequence[DetectedObject]:
         logger.debug(f"Attempting to pull {n} objects of interest from queue")
         select_stmt = (
             sa.select(DetectedObject.id)
             .where(
-                (DetectedObject.in_queue == True)
-                & (DetectedObject.binary_label == constants.POSITIVE_BINARY_LABEL)
-                & (DetectedObject.specific_label == None)
+                (DetectedObject.id.in_(self.ids()))
+                & (DetectedObject.in_queue.is_(True))
+                & (DetectedObject.specific_label.is_(None))
                 & (DetectedObject.bbox.is_not(None))
             )
             .limit(n)
@@ -327,31 +376,30 @@ class UnclassifiedObjectQueue(QueueManager):
         with get_session(self.db_path) as sesh:
             record_ids = sesh.execute(update_stmt).scalars().all()
             sesh.commit()
-            records = (
+            objs = (
                 sesh.execute(
                     sa.select(DetectedObject).where(DetectedObject.id.in_(record_ids))
                 )
                 .unique()
+                .scalars()
                 .all()
             )
-            objs = [record[0] for record in records]
             logger.info(f"Pulled {len(objs)} objects of interest from queue")
             return objs
 
 
-def all_queues(db_path):
+def all_queues(db_path, base_directory):
     return {
         q.name: q
         for q in [
-            ImageQueue(db_path),
-            DetectedObjectQueue(db_path),
-            UnclassifiedObjectQueue(db_path),
+            ImageQueue(db_path, base_directory),
+            DetectedObjectQueue(db_path, base_directory),
+            UnclassifiedObjectQueue(db_path, base_directory),
         ]
     }
 
 
 def add_image_to_queue(db_path, image_id):
-
     with get_session(db_path) as sesh:
         logger.info(f"Adding image id {image_id} to queue")
         stmt = sa.update(TrapImage).filter_by(id=image_id).values({"in_queue": True})
@@ -360,7 +408,6 @@ def add_image_to_queue(db_path, image_id):
 
 
 def add_sample_to_queue(db_path, sample_size=10):
-
     with get_session(db_path) as sesh:
         num_in_queue = sesh.query(TrapImage).filter_by(in_queue=True).count()
         if num_in_queue < sample_size:
@@ -424,13 +471,11 @@ def add_monitoring_session_to_queue(db_path, monitoring_session, limit=None):
 
 
 def images_in_queue(db_path):
-
     with get_session(db_path) as sesh:
         return sesh.query(TrapImage).filter_by(in_queue=True).count()
 
 
 def queue_counts(db_path):
-
     counts = {}
     with get_session(db_path) as sesh:
         counts["images"] = sesh.query(TrapImage).filter_by(in_queue=True).count()
@@ -454,7 +499,6 @@ def queue_counts(db_path):
 
 
 def unprocessed_counts(db_path):
-
     counts = {}
     with get_session(db_path) as sesh:
         counts["images"] = sesh.query(TrapImage).filter_by(last_processed=None).count()
@@ -474,10 +518,9 @@ def unprocessed_counts(db_path):
     return counts
 
 
-def clear_all_queues(db_path):
-
+def clear_all_queues(db_path, base_directory):
     logger.info("Clearing all queues")
 
-    for name, queue in all_queues(db_path).items():
+    for name, queue in all_queues(db_path, base_directory).items():
         logger.info(f"Clearing queue: {name}")
         queue.clear_queue()

--- a/trapdata/ml/models/base.py
+++ b/trapdata/ml/models/base.py
@@ -4,6 +4,7 @@ import torch
 from sentry_sdk import start_transaction
 
 from trapdata import logger
+from trapdata.common.types import FilePath
 from trapdata.ml.utils import (
     get_device,
     get_or_download_file,
@@ -42,7 +43,8 @@ class InferenceBaseClass:
     See examples in `classification.py` and `localization.py`
     """
 
-    db_path = None
+    db_path: str
+    deployment_path: FilePath
     name = "Unknown Inference Model"
     description = str()
     model_type = None
@@ -198,7 +200,6 @@ class InferenceBaseClass:
         torch.cuda.empty_cache()
 
         for i, batch in enumerate(self.dataloader):
-
             if not batch:
                 # @TODO review this once we switch to streaming IterableDataset
                 logger.info(f"Batch {i+1} is empty, skipping")

--- a/trapdata/ml/models/classification.py
+++ b/trapdata/ml/models/classification.py
@@ -155,7 +155,7 @@ class BinaryClassifier(EfficientNetClassifier):
 
     def get_dataset(self):
         dataset = ClassificationIterableDatabaseDataset(
-            queue=DetectedObjectQueue(self.db_path),
+            queue=DetectedObjectQueue(self.db_path, self.deployment_path),
             image_transforms=self.get_transforms(),
             batch_size=self.batch_size,
         )
@@ -190,7 +190,7 @@ class SpeciesClassifier:
 
     def get_dataset(self):
         dataset = ClassificationIterableDatabaseDataset(
-            queue=UnclassifiedObjectQueue(self.db_path),
+            queue=UnclassifiedObjectQueue(self.db_path, self.deployment_path),
             image_transforms=self.get_transforms(),
             batch_size=self.batch_size,
         )

--- a/trapdata/ml/models/localization.py
+++ b/trapdata/ml/models/localization.py
@@ -123,7 +123,7 @@ class ObjectDetector(InferenceBaseClass):
 
     def get_dataset(self):
         dataset = LocalizationIterableDatabaseDataset(
-            queue=ImageQueue(self.db_path),
+            queue=ImageQueue(self.db_path, self.deployment_path),
             image_transforms=self.get_transforms(),
             batch_size=self.batch_size,
         )

--- a/trapdata/pipeline.py
+++ b/trapdata/pipeline.py
@@ -4,8 +4,7 @@ from trapdata import logger
 from trapdata import ml
 
 
-def start_pipeline(db_path, config, single=False):
-
+def start_pipeline(db_path, deployment_path, config, single=False):
     user_data_path = pathlib.Path(config.get("paths", "user_data_path"))
     logger.info(f"Local user data path: {user_data_path}")
     num_workers = int(config.get("performance", "num_workers"))
@@ -14,6 +13,7 @@ def start_pipeline(db_path, config, single=False):
     Model_1 = ml.models.object_detectors[model_1_name]
     model_1 = Model_1(
         db_path=db_path,
+        deployment_path=deployment_path,
         user_data_path=user_data_path,
         batch_size=int(config.get("performance", "localization_batch_size")),
         num_workers=num_workers,
@@ -26,6 +26,7 @@ def start_pipeline(db_path, config, single=False):
     Model_2 = ml.models.binary_classifiers[model_2_name]
     model_2 = Model_2(
         db_path=db_path,
+        deployment_path=deployment_path,
         user_data_path=user_data_path,
         batch_size=int(config.get("performance", "classification_batch_size")),
         num_workers=num_workers,
@@ -38,6 +39,7 @@ def start_pipeline(db_path, config, single=False):
     Model_3 = ml.models.species_classifiers[model_3_name]
     model_3 = Model_3(
         db_path=db_path,
+        deployment_path=deployment_path,
         user_data_path=user_data_path,
         batch_size=int(config.get("performance", "classification_batch_size")),
         num_workers=num_workers,

--- a/trapdata/tests/test_pipeline.py
+++ b/trapdata/tests/test_pipeline.py
@@ -29,26 +29,31 @@ from trapdata.ml.models.classification import (
 
 # @newrelic.agent.background_task()
 def end_to_end(db_path, image_base_directory, sample_size):
-
     # db_path = ":memory:"
     get_db(db_path, create=True)
 
     get_or_create_monitoring_sessions(db_path, image_base_directory)
 
-    clear_all_queues(db_path)
+    clear_all_queues(db_path, image_base_directory)
     add_sample_to_queue(db_path, sample_size=sample_size)
     num_images = images_in_queue(db_path)
     logger.info(f"Images in queue: {num_images}")
     assert num_images == sample_size
 
     if torch.cuda.is_available():
-        object_detector = MothObjectDetector_FasterRCNN(db_path=db_path, batch_size=2)
+        object_detector = MothObjectDetector_FasterRCNN(
+            db_path=db_path, deployment_path=image_base_directory, batch_size=2
+        )
     else:
         object_detector = GenericObjectDetector_FasterRCNN_MobileNet(
-            db_path=db_path, batch_size=2
+            db_path=db_path, deployment_path=image_base_directory, batch_size=2
         )
-    moth_nonmoth_classifier = MothNonMothClassifier(db_path=db_path, batch_size=300)
-    species_classifier = UKDenmarkMothSpeciesClassifier(db_path=db_path, batch_size=300)
+    moth_nonmoth_classifier = MothNonMothClassifier(
+        db_path=db_path, deployment_path=image_base_directory, batch_size=300
+    )
+    species_classifier = UKDenmarkMothSpeciesClassifier(
+        db_path=db_path, deployment_path=image_base_directory, batch_size=300
+    )
 
     check_db(db_path, quiet=False)
 

--- a/trapdata/ui/main.py
+++ b/trapdata/ui/main.py
@@ -95,7 +95,11 @@ class Queue(Label):
             task_name = "Trapdata Queue Processor"
             self.bgtask = threading.Thread(
                 target=partial(
-                    start_pipeline, self.app.db_path, self.app.config, single
+                    start_pipeline,
+                    self.app.db_path,
+                    self.app.image_base_path,
+                    self.app.config,
+                    single,
                 ),
                 daemon=True,  # PyTorch will be killed abruptly, leaving memory in GPU
                 name=task_name,

--- a/trapdata/ui/playback.py
+++ b/trapdata/ui/playback.py
@@ -65,7 +65,6 @@ class AnnotatedImage(Widget):
     bg = ObjectProperty()
 
     def __init__(self, *args, **kwargs):
-
         super().__init__(*args, **kwargs)
 
         app = App.get_running_app()
@@ -75,7 +74,6 @@ class AnnotatedImage(Widget):
 
         # Arranging Canvas
         with self.canvas:
-
             # Update canvas when the window size changes
             self.bind(pos=self.update_rect, size=self.update_rect)
 
@@ -89,7 +87,6 @@ class AnnotatedImage(Widget):
         self.draw()
 
     def draw(self, *args):
-
         self.canvas.clear()
 
         if not self.image_path.exists():
@@ -356,7 +353,7 @@ class PreviewWindow(RelativeLayout):
         @TODO this should skip the queue all together and just process the image in one shot/chain
         """
         app = App.get_running_app()
-        clear_all_queues(app.db_path)
+        clear_all_queues(app.db_path, app.image_base_path)
         delete_objects_for_image(app.db_path, self.current_sample.id)
         add_image_to_queue(app.db_path, self.current_sample.id)
         app.start_queue(single=True)

--- a/trapdata/ui/queue.py
+++ b/trapdata/ui/queue.py
@@ -96,7 +96,7 @@ class QueueStatusTable(BoxLayout):
         ]
         app = App.get_running_app()
 
-        queues = list(all_queues(app.db_path).items())
+        queues = list(all_queues(app.db_path, app.image_base_path).items())
 
         def hacky_status(queue, previous_queue=None):
             # Temporary solution until we have a process for each queue


### PR DESCRIPTION
Previously the queue screen displayed unprocessed images from all trap directories that were previously scanned. The image processing pipeline was likely processing extra images from non-active traps as well. This PR scopes all queries in each processing queue to only select images & objects from the currently active trap directory. 

