### PR TITLE
Fix duplicate tracks

### DIFF
--- a/trapdata/db/models/detections.py
+++ b/trapdata/db/models/detections.py
@@ -268,7 +268,11 @@ class DetectedObject(db.Base):
 
 
 def save_detected_objects(
-    db_path, image_ids, detected_objects_data, user_data_path=None
+    db_path,
+    image_ids,
+    detected_objects_data,
+    user_data_path=None,
+    delete_existing=True,
 ):
     orm_objects = []
     with db.get_session(db_path) as sesh:
@@ -282,6 +286,14 @@ def save_detected_objects(
 
     with db.get_session(db_path) as sesh:
         for image, detected_objects in zip(images, detected_objects_data):
+            existing_objects = image.detected_objects
+            if delete_existing and len(existing_objects):
+                logger.info(
+                    f"Deleting {len(existing_objects)} existing objects for image {image.id}"
+                )
+                for existing_obj in existing_objects:
+                    sesh.delete(existing_obj)
+
             image.last_processed = timestamp
 
             # sesh.add(image)

--- a/trapdata/ui/queue.py
+++ b/trapdata/ui/queue.py
@@ -118,7 +118,9 @@ class QueueStatusTable(BoxLayout):
         for i, (name, queue) in enumerate(queues):
             clear_button = Button(text="Deque all")
             clear_button.bind(on_release=partial(queue.clear_queue))
-            add_button = Button(text="Queue all")  # Add remaining unprocessed
+            add_button = Button(
+                text="Queue \nunprocessed", halign="center"
+            )  # Add remaining unprocessed
             add_button.bind(on_release=partial(queue.add_unprocessed))
 
             # try:


### PR DESCRIPTION
Detections were being repeated in the summary view. I believe this is because multiple detections with the same bbox were being saved. I am not sure the root of this issue (is it the object detection model itself?) but these commits should prevent classification and tracking of objects with the exact same bbox.